### PR TITLE
Fix shader error

### DIFF
--- a/Assets/XPostProcessing/ShaderLibrary/XPostProcessing.hlsl
+++ b/Assets/XPostProcessing/ShaderLibrary/XPostProcessing.hlsl
@@ -9,7 +9,6 @@
 #include "NoiseLibrary.hlsl"
 
 TEXTURE2D_X_FLOAT(_CameraDepthTexture);
-float4 _BlitTexture_TexelSize;
 
 half4 GetScreenColor(float2 uv)
 {


### PR DESCRIPTION
Remove "_BlitTexture_TexelSize" what has been redefined in "Packages/com.unity.render-pipelines.core/Runtime/Utilities/Blit.hlsl"